### PR TITLE
chore: set live service_name to temp value

### DIFF
--- a/terraform/groups/ch-account-ui/profiles/live-eu-west-2/live/vars
+++ b/terraform/groups/ch-account-ui/profiles/live-eu-west-2/live/vars
@@ -1,4 +1,5 @@
 environment = "live"
-domain_name = "company-information.service.gov.uk""
+domain_name = "company-information.service.gov.uk"
 create_route53_record = true
-route53_zone = "company-information.service.gov.uk""
+route53_zone = "company-information.service.gov.uk"
+service_name = "amido-ui"


### PR DESCRIPTION
The live URL hasn't been decided yet so we are setting a temporary one.