### PR TITLE
feat: enable storybook to run without next-js app

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,17 +1,18 @@
-const path = require('path');
+const path = require("path");
 
 module.exports = {
-  "stories": [
+  stories: [
     "../stories/**/*.stories.mdx",
     "../stories/**/*.stories.@(js|jsx|ts|tsx)",
     "../components/**/*.stories.mdx",
-    "../components/**/*.stories.@(js|jsx|ts|tsx)"
+    "../components/**/*.stories.@(js|jsx|ts|tsx)",
   ],
-  "addons": [
+  addons: [
     "@storybook/addon-links",
     "@storybook/addon-essentials",
-    "storybook-addon-next-router"
+    "storybook-addon-next-router",
   ],
+  staticDirs: ["../public"],
   webpackFinal: async (config, { configType }) => {
     // `configType` has a value of 'DEVELOPMENT' or 'PRODUCTION'
     // You can change the configuration based on that.
@@ -20,11 +21,11 @@ module.exports = {
     // Make whatever fine-grained changes you need
     config.module.rules.push({
       test: /\.scss$/,
-      use: ['style-loader', 'css-loader', 'sass-loader'],
-      include: path.resolve(__dirname, '../'),
+      use: ["style-loader", "css-loader", "sass-loader"],
+      include: path.resolve(__dirname, "../"),
     });
 
     // Return the altered config
     return config;
-  }
-}
+  },
+};

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,4 +1,4 @@
-<script type="text/javascript" src="http://localhost:3000/js/govuk-3.13.0.min.js"></script>
+<script type="text/javascript" src="js/govuk-3.13.0.min.js"></script>
 <script>window.GOVUKFrontend.initAll()</script>
 <script>
   if(!_paq){ 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "next lint --dir pages --dir components --dir services",
     "prepare": "husky install",
     "storybook-config": "NODE_OPTIONS=--openssl-legacy-provider BROWSER=none",
-    "storybook": "npm run storybook-config start-storybook -s ./public -p 3001",
+    "storybook": "npm run storybook-config start-storybook -p 3001",
     "build-storybook": "npm run storybook-config build-storybook"
   },
   "engines": {


### PR DESCRIPTION
WHAT
Storybook could not run in isolation and required the Next.js application to also be running.

WHY
We were using a legacy way of providing our static file path to the required javascript files.

HOW
Update the configuration for storybook.