### PR TITLE
fix: remove company fetch from manage account page

### DIFF
--- a/pages/account/manage.js
+++ b/pages/account/manage.js
@@ -12,7 +12,7 @@ import useFRAuth from '../../services/useFRAuth'
 import { getUserFields } from '../../services/forgerock'
 
 const ManageAccount = ({ errors, lang }) => {
-  const { profile, accessToken, companyData } = useFRAuth({ fetchCompanyData: true })
+  const { profile, accessToken } = useFRAuth()
   const [preferences, setPreferences] = useState({})
   const sub = profile?.sub
   const uiStage = 'HOME_MANAGE_ACCOUNT'
@@ -45,7 +45,6 @@ const ManageAccount = ({ errors, lang }) => {
       hasLogoutLink={true}
       hasAccountLinks
       accountLinksItem={6}
-      messages={companyData.filter((company) => company.membershipStatus === 'pending').length}
     >
       <Dynamic
         componentMap={componentMap}


### PR DESCRIPTION
WHAT
remove company fetch from manage account page

WHY
We only want to call to get the data when we need it

HOW
update the config on the page