### PR TITLE
feat: add loading state to your companies page

### DIFF
--- a/components/application-specific/Loading.js
+++ b/components/application-specific/Loading.js
@@ -12,7 +12,7 @@ const Loading = () => {
     return () => clearTimeout(timeOut)
   })
 
-  return display ? <BodyText>Page loading...</BodyText> : null
+  return display ? <BodyText>Page loading<div className="loading-spinner"><div></div><div></div><div></div><div></div></div></BodyText> : null
 }
 
 export default Loading

--- a/css/global.scss
+++ b/css/global.scss
@@ -287,3 +287,60 @@
 .noPaddingRight {
   padding-right: 0;
 }
+
+.loading-spinner {
+  display: inline-block;
+  position: relative;
+  width: 80px;
+  height: 43px;
+}
+.loading-spinner div {
+  position: absolute;
+  top: 33px;
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background: #0b0c0c;
+  animation-timing-function: cubic-bezier(0, 1, 1, 0);
+}
+.loading-spinner div:nth-child(1) {
+  left: 8px;
+  animation: spinner1 0.6s infinite;
+}
+.loading-spinner div:nth-child(2) {
+  left: 8px;
+  animation: spinner2 0.6s infinite;
+}
+.loading-spinner div:nth-child(3) {
+  left: 32px;
+  animation: spinner2 0.6s infinite;
+}
+.loading-spinner div:nth-child(4) {
+  left: 56px;
+  animation: spinner3 0.6s infinite;
+}
+
+@keyframes spinner1 {
+  0% {
+    transform: scale(0);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+@keyframes spinner3 {
+  0% {
+    transform: scale(1);
+  }
+  100% {
+    transform: scale(0);
+  }
+}
+@keyframes spinner2 {
+  0% {
+    transform: translate(0, 0);
+  }
+  100% {
+    transform: translate(24px, 0);
+  }
+}

--- a/pages/account/your-companies/index.js
+++ b/pages/account/your-companies/index.js
@@ -11,6 +11,7 @@ import WithQueryParams from '../../../components/providers/WithQueryParams'
 import useFRAuth from '../../../services/useFRAuth'
 import { translateErrors } from '../../../services/errors'
 import { formatNumber } from '../../../services/formatting'
+import Loading from '../../../components/application-specific/Loading'
 
 const YourCompanies = ({ lang, queryParams }) => {
   const shouldRefresh = !!queryParams?.notifyToken || !!queryParams?.refreshData
@@ -20,7 +21,7 @@ const YourCompanies = ({ lang, queryParams }) => {
   const headingCount = useMemo(() => new HeadingCount(), [])
   const content = getStageFeatures(lang, uiStage)
   const [companies, setCompanies] = useState([])
-
+ 
   useEffect(() => {
     headingCount.reset()
   })
@@ -48,7 +49,9 @@ const YourCompanies = ({ lang, queryParams }) => {
       accountLinksItem={2}
       messages={pendingCompanies.length}
     >
-      <Dynamic
+      {loading
+        ? <Loading/>
+        : <Dynamic
         companies={companies}
         componentMap={componentMap}
         content={content}
@@ -64,8 +67,7 @@ const YourCompanies = ({ lang, queryParams }) => {
         uiStage={uiStage}
         lang={lang}
         {...queryParams}
-      />
-
+      />}
     </FeatureDynamicView>
   )
 }

--- a/pages/account/your-companies/index.js
+++ b/pages/account/your-companies/index.js
@@ -21,7 +21,7 @@ const YourCompanies = ({ lang, queryParams }) => {
   const headingCount = useMemo(() => new HeadingCount(), [])
   const content = getStageFeatures(lang, uiStage)
   const [companies, setCompanies] = useState([])
- 
+
   useEffect(() => {
     headingCount.reset()
   })


### PR DESCRIPTION
WHAT
- Add a loading state for users while their list of associated companies is being retrieved

WHY
- Users with large amount of companies are being mis-informed when waiting for the companies to be retrieved 

HOW
- Add animation to loading component
- Add loading state to your companies page
