### PR TITLE
fix: remove company name from matomo

### DIFF
--- a/services/lang/content-tokens.json
+++ b/services/lang/content-tokens.json
@@ -679,6 +679,10 @@
     "en": "You need the authentication code to add ${companyName} to your account",
     "cy": "Mae angen y cod dilysu arnoch i ychwanegu ${companyName} at eich cyfrif"
   },
+  "REQUEST_AUTHENTICATION_CODE_1.[1].PageHeading.youNeedTheAuthenticationCode.analytics": {
+    "en": "You need the authentication code to add <companyName> to your account",
+    "cy": "Mae angen y cod dilysu arnoch i ychwanegu <companyName> at eich cyfrif"
+  },
   "REQUEST_AUTHENTICATION_CODE_1.[3].BodyText.youCanRequestToHaveYourAuthenticationCode": {
     "en": "You can request to have your authentication code sent to the registered office address or your home address. It can take up to 5 working days to arrive.",
     "cy": "Gallwch ofyn i'ch cod dilysu gael ei anfon i gyfeiriad y swyddfa gofrestredig neu i'ch cyfeiriad cartref. Gall gymryd hyd at 5 diwrnod gwaith i gyrraedd."

--- a/services/stages/REQUEST_AUTH_CODE.js
+++ b/services/stages/REQUEST_AUTH_CODE.js
@@ -30,7 +30,7 @@ const REQUEST_AUTH_CODE = (lang, tokens) => [
           href: '',
           target: '_blank',
           children: tokens('REQUEST_AUTHENTICATION_CODE_1.[5].LinkText.sendAuthenticationCodeToOffice'),
-          matomo: ['trackEvent', tokens('REQUEST_AUTHENTICATION_CODE_1.[1].PageHeading.youNeedTheAuthenticationCode'), tokens('REQUEST_AUTHENTICATION_CODE_1.[5].LinkText.sendAuthenticationCodeToOffice')]
+          matomo: ['trackEvent', tokens('REQUEST_AUTHENTICATION_CODE_1.[1].PageHeading.youNeedTheAuthenticationCode.analytics'), tokens('REQUEST_AUTHENTICATION_CODE_1.[5].LinkText.sendAuthenticationCodeToOffice')]
         }
       }
     ]
@@ -47,7 +47,7 @@ const REQUEST_AUTH_CODE = (lang, tokens) => [
           href: '',
           target: '_blank',
           children: tokens('REQUEST_AUTHENTICATION_CODE_1.[6].LinkText.sendAuthenticationCodeToHome'),
-          matomo: ['trackEvent', tokens('REQUEST_AUTHENTICATION_CODE_1.[1].PageHeading.youNeedTheAuthenticationCode'), tokens('REQUEST_AUTHENTICATION_CODE_1.[6].LinkText.sendAuthenticationCodeToHome')]
+          matomo: ['trackEvent', tokens('REQUEST_AUTHENTICATION_CODE_1.[1].PageHeading.youNeedTheAuthenticationCode.analytics'), tokens('REQUEST_AUTHENTICATION_CODE_1.[6].LinkText.sendAuthenticationCodeToHome')]
         }
       }
     ]
@@ -62,7 +62,7 @@ const REQUEST_AUTH_CODE = (lang, tokens) => [
       renderAs: 'link',
       href: '/account/home/',
       testId: 'homeButton',
-      matomo: ['trackEvent', tokens('REQUEST_AUTHENTICATION_CODE_1.[1].PageHeading.youNeedTheAuthenticationCode'), tokens('REQUEST_AUTHENTICATION_CODE_1.[6].Button.returnToHomePage')]
+      matomo: ['trackEvent', tokens('REQUEST_AUTHENTICATION_CODE_1.[1].PageHeading.youNeedTheAuthenticationCode.analytics'), tokens('REQUEST_AUTHENTICATION_CODE_1.[6].Button.returnToHomePage')]
     }
   }
 ]


### PR DESCRIPTION
PBI: https://companieshouse.atlassian.net/browse/IDAM-1594

WHAT
- We need to ensure we do not capture PII data in the service analytics

WHY
- So that we do not breach our corporate data privacy requirements

HOW
- pass the text without the company name into the analytics