### PR TITLE
Idam 1594/remove company name from log

### DIFF
--- a/components/general-ui/typeography/ErrorSummary.js
+++ b/components/general-ui/typeography/ErrorSummary.js
@@ -26,10 +26,11 @@ const ErrorSummary = (props) => {
 
     if (errors.length > 0) {
       errors.forEach(error => {
+        const errorLabel = error.labelForMatomo ? error.labelForMatomo : error.label
         const errData = {
           type: 'trackEvent',
           category: 'Error',
-          action: parentPage !== undefined ? parentPage[0] + ': ' + cleanAnalytics([error.label], cleanTitle, 'ErrorSummary')[0] : 'Error: ' + cleanAnalytics([error.label], cleanTitle, 'ErrorSummary')[0],
+          action: parentPage !== undefined ? parentPage[0] + ': ' + cleanAnalytics([errorLabel], cleanTitle, 'ErrorSummary')[0] : 'Error: ' + cleanAnalytics([errorLabel], cleanTitle, 'ErrorSummary')[0],
           href: 'http://'
         }
         trackEvent(errData)

--- a/services/errors.js
+++ b/services/errors.js
@@ -63,11 +63,10 @@ export const translateErrors = (errors, lang, langSwitched = false) => {
 
       return label
     }, '')
-
+    error.labelForMatomo = translate(lang, error?.tokenForMatomo, '', error.params)
     if (!error.label) {
       error.label = `No token data for lang "${lang}" and tokens ${JSON.stringify(tokensToTry)}. Please check /services/lang/${lang}/tokens.json to ensure you have defined a token with one of these names!`
     }
-
     error.processed = true
   })
 

--- a/services/forgerock.js
+++ b/services/forgerock.js
@@ -69,6 +69,7 @@ export const normaliseErrors = (step, journeyNamespace = 'UNKNOWN', oneErrorPerF
       errors.push({
         errData: error,
         tokenNoNamespace: error.token,
+        tokenForMatomo: `${error.token}_WITHOUT_COMPANY_NAME`,
         token: `${journeyNamespace}_${error.token}`,
         label: !error.token ? error.label : undefined,
         anchor: error.anchor || undefined,

--- a/services/lang/tokens.json
+++ b/services/lang/tokens.json
@@ -208,8 +208,8 @@
     "cy": "Mae'r defnyddiwr hwn eisoes wedi'i awdurdodi i ffeilio ar gyfer ${company.name}"
   },
   "COMPANY_ALREADY_ASSOCIATED_WITHOUT_COMPANY_NAME": {
-    "en": "This user is already authorised to file for the same company",
-    "cy": "Mae'r defnyddiwr hwn eisoes wedi'i awdurdodi i ffeilio ar gyfer yr un cwmni"
+    "en": "This user is already authorised to file for this company",
+    "cy": "Mae'r defnyddiwr hwn wedi'i awdurdodi i ffeilio ar gyfer y cwmni hwn yn barod"
   },
   "AUTH_CODE_NOT_DEFINED": {
     "en": "Company must request an authentication code",

--- a/services/lang/tokens.json
+++ b/services/lang/tokens.json
@@ -209,7 +209,7 @@
   },
   "COMPANY_ALREADY_ASSOCIATED_WITHOUT_COMPANY_NAME": {
     "en": "This user is already authorised to file for the same company",
-    "cy": "Mae'r defnyddiwr hwn eisoes wedi'i awdurdodi i ffeilio ar gyfer"
+    "cy": "Mae'r defnyddiwr hwn eisoes wedi'i awdurdodi i ffeilio ar gyfer yr un cwmni"
   },
   "AUTH_CODE_NOT_DEFINED": {
     "en": "Company must request an authentication code",

--- a/services/lang/tokens.json
+++ b/services/lang/tokens.json
@@ -207,6 +207,10 @@
     "en": "This user is already authorised to file for ${company.name}",
     "cy": "Mae'r defnyddiwr hwn eisoes wedi'i awdurdodi i ffeilio ar gyfer ${company.name}"
   },
+  "COMPANY_ALREADY_ASSOCIATED_WITHOUT_COMPANY_NAME": {
+    "en": "This user is already authorised to file for the same company",
+    "cy": "Mae'r defnyddiwr hwn eisoes wedi'i awdurdodi i ffeilio ar gyfer"
+  },
   "AUTH_CODE_NOT_DEFINED": {
     "en": "Company must request an authentication code",
     "cy": "Rhaid i’r Cwmni ofyn am god dilysu"

--- a/tests/errors.test.js
+++ b/tests/errors.test.js
@@ -24,6 +24,7 @@ describe('translateErrors', () => {
     expect(translateErrors(errorData, 'en')).toStrictEqual(
       [{
         label: 'Enter an email address in the correct format, like name@example.com',
+        labelForMatomo: "",
         token: 'LOGIN_CREDENTIALS_MISSING_USERNAME',
         fieldName: 'IDToken1',
         anchor: 'IDToken1',
@@ -56,6 +57,7 @@ const newErrorData = [
   {
     token: 'LOGIN_CREDENTIALS_MISSING_USERNAME',
     label: 'Enter an email address in the correct format, like name@example.com',
+    labelForMatomo: "",
     anchor: 'IDToken1',
     fieldName: 'IDToken1',
     processed: true


### PR DESCRIPTION
WHAT  
At the moment Matomo logs reveal company names 
WHY  
This means security breaches.
HOW  
Separate the format of Matomo log from page displayed messages