### PR TITLE
fix: add companies refresh logic to session

### DIFF
--- a/pages/account/login.js
+++ b/pages/account/login.js
@@ -75,6 +75,10 @@ const Login = ({ lang, queryParams }) => {
 
   const { errors = [], company, ...restPageProps } = stepPageProps
 
+  if (uiStage === 'EWF_LOGIN_5') {
+    sessionStorage.setItem('refresh', 'true')
+  }
+
   return (
     <FeatureDynamicView
       onSubmit={onSubmit}

--- a/pages/account/login.js
+++ b/pages/account/login.js
@@ -75,9 +75,11 @@ const Login = ({ lang, queryParams }) => {
 
   const { errors = [], company, ...restPageProps } = stepPageProps
 
-  if (uiStage === 'EWF_LOGIN_5') {
-    sessionStorage.setItem('refresh', 'true')
-  }
+  useEffect(() => {
+    if (uiStage === 'EWF_LOGIN_5') {
+      sessionStorage.setItem('refresh', 'true')
+    }
+  }, [uiStage])
 
   return (
     <FeatureDynamicView

--- a/pages/account/login.js
+++ b/pages/account/login.js
@@ -77,7 +77,7 @@ const Login = ({ lang, queryParams }) => {
 
   useEffect(() => {
     if (uiStage === 'EWF_LOGIN_5') {
-      sessionStorage.setItem('refresh', 'true')
+      sessionStorage.setItem('refresh', true)
     }
   }, [uiStage])
 

--- a/services/useFRAuth.js
+++ b/services/useFRAuth.js
@@ -77,7 +77,7 @@ const useFRAuth = (config = {}) => {
       setLoading(true)
       setErrors([])
       // check the session for company data
-      if (sessionStorage.getItem('companyData') && refresh === false) {
+      if (sessionStorage.getItem('companyData') && refresh === false && sessionStorage.getItem('refresh') !== 'true') {
         log.debug('We have company data in the session')
         const companiesSessionData = JSON.parse(sessionStorage.getItem('companyData'))
         setCompanyData(JSON.parse(sessionStorage.getItem('companyData')))
@@ -105,14 +105,15 @@ const useFRAuth = (config = {}) => {
         getCompaniesAssociatedWithUser(accessToken, sub, companySearch, companyStatus).then((data) => {
           setCompanyData(data.companies)
           sessionStorage.setItem('companyData', JSON.stringify(data.companies))
-          setLoading(false)
+          sessionStorage.setItem('refresh', 'false')
         }).catch((err) => {
           setErrors([{
             errData: err, // Add the errData key to pass along the original error info
             token: 'ERROR_UNKNOWN', // We don't know the error
             stage: 'GENERIC_ERROR' // Switch the UI to show the GENERIC_ERROR stage features
-          }])
-          setLoading(false)
+          }]).finally(() => {
+            setLoading(false)
+          })
         }
         )
       }

--- a/services/useFRAuth.js
+++ b/services/useFRAuth.js
@@ -77,7 +77,7 @@ const useFRAuth = (config = {}) => {
       setLoading(true)
       setErrors([])
       // check the session for company data
-      if (sessionStorage.getItem('companyData') && refresh === false && sessionStorage.getItem('refresh') !== 'true') {
+      if (sessionStorage.getItem('companyData') && refresh === false && !sessionStorage.getItem('refresh')) {
         log.debug('We have company data in the session')
         const companiesSessionData = JSON.parse(sessionStorage.getItem('companyData'))
         setCompanyData(JSON.parse(sessionStorage.getItem('companyData')))
@@ -105,7 +105,7 @@ const useFRAuth = (config = {}) => {
         getCompaniesAssociatedWithUser(accessToken, sub, companySearch, companyStatus).then((data) => {
           setCompanyData(data.companies)
           sessionStorage.setItem('companyData', JSON.stringify(data.companies))
-          sessionStorage.setItem('refresh', 'false')
+          sessionStorage.setItem('refresh', false)
         }).catch((err) => {
           setErrors([{
             errData: err, // Add the errData key to pass along the original error info


### PR DESCRIPTION
WHAT
When a company is added and we get redirect to another site the company data is not refreshed.
WHY
We always want the customer data up to date
HOW
Add logic into the session storage allowing the company data to refresh