### PR TITLE
feat: update sign in journey to make mobile otp optional for email

### DIFF
--- a/services/lang/content-tokens.json
+++ b/services/lang/content-tokens.json
@@ -1492,15 +1492,15 @@
   },
   "SHARED.ifNotRecievedEmail": {
     "en": "If you still have not recieved the email, we can ",
-    "cy": "If you still have not recieved the email, we can "
+    "cy": "Os nad ydych wedi derbyn yr e-bost o hyd, gallwn "
   },
   "SHARED.sendSecurityCodeToMobile": {
     "en": "send the security code to your mobile phone ",
-    "cy": "send the security code to your mobile phone instead "
+    "cy": "anfon y cod diogelwch i'ch ffôn symudol "
   },
   "SHARED.instead": {
     "en": "instead.",
-    "cy": "instead."
+    "cy": "yn lle hynny."
   },
   "UPDATE_PHONE_1.[0].BrowserTitle.changeYourMobileNumber": {
     "en": "Manage account - Update your mobile number",

--- a/services/lang/content-tokens.json
+++ b/services/lang/content-tokens.json
@@ -1490,6 +1490,18 @@
     "en": "Industrial action - disruption possible",
     "cy": "Gweithredu diwydiannol - tarfu posib"
   },
+  "SHARED.ifNotRecievedEmail": {
+    "en": "If you still have not recieved the email, we can ",
+    "cy": "If you still have not recieved the email, we can "
+  },
+  "SHARED.sendSecurityCodeToMobile": {
+    "en": "send the security code to your mobile phone ",
+    "cy": "send the security code to your mobile phone instead "
+  },
+  "SHARED.instead": {
+    "en": "instead.",
+    "cy": "instead."
+  },
   "UPDATE_PHONE_1.[0].BrowserTitle.changeYourMobileNumber": {
     "en": "Manage account - Update your mobile number",
     "cy": "Rheoli eich cyfrif - Diweddaru eich rhif ffôn symudol"

--- a/services/stages/shared/emailOtp.js
+++ b/services/stages/shared/emailOtp.js
@@ -161,6 +161,45 @@ const emailOtp = (lang, tokens) => ([
             }
           }
         ]
+      },
+      {
+        conditional: {
+          prop: '${phoneNumber}',
+          operator: 'is'
+        },
+        component: 'BodyText',
+        props: {},
+        content: [
+          {
+            component: 'SpanText',
+            props: {
+              children: tokens('SHARED.ifNotRecievedEmail')
+            }
+          },
+          {
+            component: 'LinkText',
+            props: {
+              children: tokens('SHARED.sendSecurityCodeToMobile'),
+              handler: {
+                name: 'onSecondarySubmit',
+                params: {
+                  target: 'IDToken5',
+                  value: 2,
+                  noValidate: true
+                }
+              },
+              href: '',
+              testId: 'resendEmail',
+              matomo: ['trackEvent', tokens('SHARED.checkYourEmail'), tokens('SHARED.askUsToSendYouAnotherEmail')]
+            }
+          },
+          {
+            component: 'SpanText',
+            props: {
+              children: tokens('SHARED.instead')
+            }
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
PBI: https://companieshouse.atlassian.net/jira/software/c/projects/IDAM/boards/408?modal=detail&selectedIssue=IDAM-1582

WHAT
Add new hyperlink to send SMS to email OTP confirm if you have mobile number

WHY
Some customers may want to send an SMS if they have an issue with their email account

HOW
Update schema and add new text and component