### PR TITLE
fix: provide the right data for auth person companies page

### DIFF
--- a/pages/account/your-companies/authorised-person.js
+++ b/pages/account/your-companies/authorised-person.js
@@ -15,8 +15,8 @@ import { useRouter } from 'next/router'
 
 const AuthorisedPerson = ({ errors, lang, queryParams }) => {
   const router = useRouter()
-  const { companyNumber, userId } = queryParams
-  const { companyData, loading } = useFRAuth({ fetchCompanyData: true, refresh: true })
+  const { companyNumber, userId, page } = queryParams
+  const { companyData, loading } = useFRAuth({ fetchCompanyData: true, refresh: true, currentPage: Number(page) || 1 })
   const uiStage = 'HOME_AUTHORISED_PERSON'
   const headingCount = useMemo(() => new HeadingCount(), [])
   const content = getStageFeatures(lang, uiStage)

--- a/services/forgerock.js
+++ b/services/forgerock.js
@@ -442,7 +442,8 @@ export const getCompaniesAssociatedWithUser = async (accessToken, userId, compan
             currentUser: member._id === userId,
             detailsPath: generateQueryUrl('/account/your-companies/authorised-person', {
               companyNumber: company.number,
-              userId: member._id
+              userId: member._id,
+              page: currentPage
             })
           })
           )


### PR DESCRIPTION
WHAT: After the pagination change the page had no data being displayed

WHY: The page didn't have the context of what page it was on to get the right data to show

HOW: Update the link and pass the page number in where needed