### PR TITLE
fix: update routing to include page number

### DIFF
--- a/pages/account/authorise/[pageStep].js
+++ b/pages/account/authorise/[pageStep].js
@@ -29,6 +29,7 @@ const InviteUser = ({ lang, queryParams }) => {
   const formRef = useRef()
   const headingCount = useMemo(() => new HeadingCount(), [])
   const { pageStep, token, companyNumber, action, userId } = queryParams
+  const currentPage = Number(queryParams?.page) || 1
 
   useEffect(() => {
     headingCount.reset()
@@ -64,14 +65,16 @@ const InviteUser = ({ lang, queryParams }) => {
         notifyToken: 'resendSuccess',
         notifyId: notificationId,
         companyNumber,
-        userId
+        userId,
+        page: currentPage
       })
     } else {
       stepPageProps.authoriseSuccessPath = generateQueryUrl('/account/your-companies/', {
         notifyToken: 'authSuccess',
         notifyId: notificationId,
         invitedUser: stepPageProps.invitedUser,
-        companyName: stepPageProps.company.name
+        companyName: stepPageProps.company.name,
+        page: currentPage
       })
     }
   }
@@ -80,7 +83,8 @@ const InviteUser = ({ lang, queryParams }) => {
   if (uiStage === 'INVITE_USER_3') {
     stepPageProps.acceptSuccessPath = generateQueryUrl('/account/your-companies/', {
       notifyToken: `${action}Success`,
-      companyName: stepPageProps.company.name
+      companyName: stepPageProps.company.name,
+      page: currentPage
     })
   }
 

--- a/pages/account/your-companies/authorised-person.js
+++ b/pages/account/your-companies/authorised-person.js
@@ -24,7 +24,7 @@ const AuthorisedPerson = ({ errors, lang, queryParams }) => {
   const user = company?.members?.filter((member) => (userId === member._id))[0]
 
   if (!loading && company) {
-    company.resendPath = generateQueryUrl('/account/authorise/_start/', { companyNumber: company.number, companyName: company.name, userId })
+    company.resendPath = generateQueryUrl('/account/authorise/_start/', { companyNumber: company.number, companyName: company.name, userId, page })
     company.removeAuthorisedPath = generateQueryUrl('/account/your-companies/remove-authorised-person/', { companyNumber: company.number, userId })
     company.removePendingdPath = generateQueryUrl('/account/your-companies/remove-authorised-person/', { companyNumber: company.number, userId, pending: true })
   }


### PR DESCRIPTION
WHAT
Some links did not provided a page number causing some data not to be found
WHY
We always want to display the right information to the customer
HOW
Add the page number to the URL parameters