### PR TITLE
fix: update urls to include page number and search

### DIFF
--- a/services/forgerock.js
+++ b/services/forgerock.js
@@ -421,21 +421,29 @@ export const getCompaniesAssociatedWithUser = async (accessToken, userId, compan
           ...company,
           authorisePath: generateQueryUrl('/account/authorise/_start/', {
             companyNumber: company.number,
-            companyName: company.name
+            companyName: company.name,
+            page: currentPage,
+            ...(companySearch && { search: companySearch })
           }),
           filePath: generateQueryUrl(CH_EWF_AUTHENTICATED_ENTRY_URL, {
             companyNo: company.number,
-            jurisdiction: company.jurisdiction
+            jurisdiction: company.jurisdiction,
+            page: currentPage,
+            ...(companySearch && { search: companySearch })
           }),
           acceptPath: generateQueryUrl('/account/authorise/_start/', {
             companyNumber: company.number,
             companyName: company.name,
-            action: 'accept'
+            action: 'accept',
+            page: currentPage,
+            ...(companySearch && { search: companySearch })
           }),
           declinePath: generateQueryUrl('/account/authorise/_start/', {
             companyNumber: company.number,
             companyName: company.name,
-            action: 'decline'
+            action: 'decline',
+            page: currentPage,
+            ...(companySearch && { search: companySearch })
           }),
           members: company.members?.map((member) => ({
             ...member,


### PR DESCRIPTION
WHAT
Update more urls to include the correct url parameters
WHY
Without it the API cannot get the data
HOW
Add  params to URLs where needed