### PR TITLE
fix: change track event on mobile security code

### DIFF
--- a/services/stages/shared/emailOtp.js
+++ b/services/stages/shared/emailOtp.js
@@ -190,7 +190,7 @@ const emailOtp = (lang, tokens) => ([
               },
               href: '',
               testId: 'resendEmail',
-              matomo: ['trackEvent', tokens('SHARED.checkYourEmail'), tokens('SHARED.askUsToSendYouAnotherEmail')]
+              matomo: ['trackEvent', tokens('SHARED.sendSecurityCodeToMobile')]
             }
           },
           {


### PR DESCRIPTION
WHAT
The analytics event was wrong for the OTP mobile link
WHY
We want to track all events properly
HOW
Update the text value