### PR TITLE
update to show pagination only when page loaded

### DIFF
--- a/pages/account/your-companies/index.js
+++ b/pages/account/your-companies/index.js
@@ -29,7 +29,6 @@ const YourCompanies = ({ lang, queryParams }) => {
     refresh: true,
     currentPage
   })
-
   const uiStage = 'HOME_YOUR_COMPANIES'
   const headingCount = useMemo(() => new HeadingCount(), [])
   const { push } = useRouter()
@@ -78,7 +77,7 @@ const YourCompanies = ({ lang, queryParams }) => {
       startPage={pagination.startPage}
       displayPrev={currentPage > 1}
       displayNext={currentPage < pagination.totalPages}
-      display={pagination.totalPages > 1}
+      display={pagination.totalPages > 1 && !loading}
       clickNext={() => clickNext()}
       clickPrevious={() => clickPrevious()}
       clickToSelectPage={(e) => clickToSelectPage(e)}

--- a/services/pagination.js
+++ b/services/pagination.js
@@ -3,7 +3,10 @@ const generateEllipsisBreaks = (pages, currentPage) => {
   let right = []
   let displayedPages = pages
   left = pages?.filter((x) => x < currentPage + 2)
-  let pageEllipsis = pages?.filter((x) => x === left.length + 1)
+  let pageEllipsis =
+    currentPage + 2 !== pages?.length
+      ? pages?.filter((x) => x === currentPage + 2)
+      : []
   right = pages?.filter((x) => x >= pages[pages.length - 1])
   if (left?.length > 5) {
     pageEllipsis.unshift(2)


### PR DESCRIPTION
WHAT  
Pagination displayed before page finished loading and last page not showing on some button clicks
WHY  
BUGS
HOW  
Pagination would only show when page has finished loading
Last page number would always show no matter pages selected