### PR TITLE
added govuk-body class to cookie-banner p elements

### DIFF
--- a/components/general-ui/interaction/CookieBanners.js
+++ b/components/general-ui/interaction/CookieBanners.js
@@ -49,7 +49,7 @@ const CookieBanners = (props) => {
               <div className="govuk-grid-column-two-thirds">
                 <h2 className="govuk-cookie-banner__heading govuk-heading-m">{translate(lang, 'COOKIE_BANNER_HEADING')}</h2>
 
-                <div className="govuk-cookie-banner__content">
+                <div className="govuk-cookie-banner__content govuk-body">
                   <p>{translate(lang, 'COOKIE_BANNER_CONTENT')}</p>
                   <p>{translate(lang, 'COOKIE_BANNER_CONTENT_2')}</p>
                 </div>
@@ -75,7 +75,7 @@ const CookieBanners = (props) => {
             <div className="govuk-grid-row">
               <div className="govuk-grid-column-two-thirds">
 
-                <div className="govuk-cookie-banner__content">
+                <div className="govuk-cookie-banner__content govuk-body">
                   <p>{translate(lang, 'COOKIE_BANNER_CONTENT_ACCEPT')}<a className="govuk-link" href="https://ewf.companieshouse.gov.uk/cookies">{translate(lang, 'COOKIE_BANNER_CONTENT_ACCEPT_LINK')}</a>{translate(lang, 'COOKIE_BANNER_CONTENT_ACCEPT_2')}</p>
                 </div>
               </div>
@@ -96,7 +96,7 @@ const CookieBanners = (props) => {
             <div className="govuk-grid-row">
               <div className="govuk-grid-column-two-thirds">
 
-                <div className="govuk-cookie-banner__content">
+                <div className="govuk-cookie-banner__content govuk-body">
                   <p>{translate(lang, 'COOKIE_BANNER_CONTENT_REJECT')}<a className="govuk-link" href="https://ewf.companieshouse.gov.uk/cookies">{translate(lang, 'COOKIE_BANNER_CONTENT_REJECT_LINK')}</a>{translate(lang, 'COOKIE_BANNER_CONTENT_REJECT_2')}</p>
                 </div>
               </div>


### PR DESCRIPTION
Added the govuk-body class to the required elements in the cookie-banner component in order for them to be displayed with the correct font. 
