### PR TITLE
fix: add sign out to 'remove digital auth' page

### DIFF
--- a/pages/account/your-companies/remove-authorised-person.js
+++ b/pages/account/your-companies/remove-authorised-person.js
@@ -60,6 +60,7 @@ const RemoveAuthorisedPerson = ({ lang, queryParams }) => {
       accountLinksItem={2}
       formRef={formRef}
       hasAccountLinks
+      hasLogoutLink={true}
       hasBackLink={false}
       onSubmit={onSubmit}
     >


### PR DESCRIPTION
WHAT
CHAS-17 was raised by the customer, re an issue where the Sign Out button was missing from the header in the _remove digital authorisation_ page, used to remove access for a user a company.
WHY
The hasLogoutLink variable was missing from the FeatureDynamicView module in the remove-authorised-person component, found under pages/account/manage/your-companies
HOW
Added the hasLogoutLink variable with the value set to true.