### PR TITLE
Chas 23   fix language carrying over to legacy web filing

### DIFF
--- a/components/application-specific/AccountLinks.js
+++ b/components/application-specific/AccountLinks.js
@@ -24,7 +24,7 @@ const AccountLinks = (props) => {
           <div className="account-menu">
             <AccountLinkItem current={currentItem === 1} href="/account/home" text={translate(lang, 'ACCOUNT_LINKS_HOME')}/>
             <AccountLinkItem current={currentItem === 2} href="/account/your-companies" text={translate(lang, 'ACCOUNT_LINKS_YOUR_COMPANIES')}/>
-            <AccountLinkItem current={currentItem === 3} href={CH_EWF_RECENT_FILINGS_URL} text={translate(lang, 'ACCOUNT_LINKS_YOUR_FILINGS')}/>
+            <AccountLinkItem current={currentItem === 3} href={`${CH_EWF_RECENT_FILINGS_URL}?lang=${lang}`} text={translate(lang, 'ACCOUNT_LINKS_YOUR_FILINGS')}/>
             <AccountLinkItem current={currentItem === 4} href={CH_EWF_AUTHENTICATED_ENTRY_URL} text={translate(lang, 'ACCOUNT_LINKS_FILE_FOR_A_COMPANY')}/>
             <AccountLinkItem current={currentItem === 6} href="/account/manage" text={translate(lang, 'ACCOUNT_LINKS_MANAGE_ACCOUNT')}/>
           </div>

--- a/components/general-ui/interaction/CookieBanners.js
+++ b/components/general-ui/interaction/CookieBanners.js
@@ -49,7 +49,7 @@ const CookieBanners = (props) => {
               <div className="govuk-grid-column-two-thirds">
                 <h2 className="govuk-cookie-banner__heading govuk-heading-m">{translate(lang, 'COOKIE_BANNER_HEADING')}</h2>
 
-                <div className="govuk-cookie-banner__content">
+                <div className="govuk-cookie-banner__content govuk-body">
                   <p>{translate(lang, 'COOKIE_BANNER_CONTENT')}</p>
                   <p>{translate(lang, 'COOKIE_BANNER_CONTENT_2')}</p>
                 </div>
@@ -75,7 +75,7 @@ const CookieBanners = (props) => {
             <div className="govuk-grid-row">
               <div className="govuk-grid-column-two-thirds">
 
-                <div className="govuk-cookie-banner__content">
+                <div className="govuk-cookie-banner__content govuk-body">
                   <p>{translate(lang, 'COOKIE_BANNER_CONTENT_ACCEPT')}<a className="govuk-link" href="https://ewf.companieshouse.gov.uk/cookies">{translate(lang, 'COOKIE_BANNER_CONTENT_ACCEPT_LINK')}</a>{translate(lang, 'COOKIE_BANNER_CONTENT_ACCEPT_2')}</p>
                 </div>
               </div>
@@ -96,7 +96,7 @@ const CookieBanners = (props) => {
             <div className="govuk-grid-row">
               <div className="govuk-grid-column-two-thirds">
 
-                <div className="govuk-cookie-banner__content">
+                <div className="govuk-cookie-banner__content govuk-body">
                   <p>{translate(lang, 'COOKIE_BANNER_CONTENT_REJECT')}<a className="govuk-link" href="https://ewf.companieshouse.gov.uk/cookies">{translate(lang, 'COOKIE_BANNER_CONTENT_REJECT_LINK')}</a>{translate(lang, 'COOKIE_BANNER_CONTENT_REJECT_2')}</p>
                 </div>
               </div>


### PR DESCRIPTION
This is related to CHAS-23 which was raised to us as the language choice was not properly carrying  over to the legacy web filing application when clicking the link to it in the nav bar. 