### PR TITLE
fix: tfsec remove unused staging logging auth

### DIFF
--- a/terraform/groups/ch-account-ui/auth.tf
+++ b/terraform/groups/ch-account-ui/auth.tf
@@ -38,15 +38,6 @@ resource "aws_iam_role_policy" "auth_lambda" {
   "Statement": [
     {
       "Action": [
-        "logs:CreateLogStream",
-        "logs:PutLogEvents",
-        "logs:CreateLogGroup"
-      ],
-      "Effect": "Allow",
-      "Resource": "*"
-    },
-    {
-      "Action": [
         "ssm:GetParameter"
       ],
       "Effect": "Allow",


### PR DESCRIPTION
WHAT
Removing the AWS IAM role policy statement that was used to allow lambdas to produce logs for all resources using a wildcard permission, after verifying that this is only enabled in staging and not in live or dev, and that no frontend-ui logs are available in AWS.
WHY
The wildcard allow policy was highlighted by tfsec as a vulnerability.
HOW
The policy snippet granting allow access to create log streams, put log events and create log groups was removed.
    {
      "Action": [
        "logs:CreateLogStream",
        "logs:PutLogEvents",
        "logs:CreateLogGroup"
      ],
      "Effect": "Allow",
      "Resource": "*"
    },