### PR TITLE
fix: CHAS-29 define missing error token

### DIFF
--- a/services/lang/tokens.json
+++ b/services/lang/tokens.json
@@ -411,6 +411,10 @@
     "en": "Unknown error occurred",
     "cy": "Ymddiheuriadau, mae yna broblem gyda'r gwasanaeth"
   },
+  "INVITE_USER_GENERIC_ERROR": {
+    "en": "Unknown error occurred",
+    "cy": "Ymddiheuriadau, mae yna broblem gyda'r gwasanaeth"
+  },
   "INVITE_USER_ADD_USER_TO_COMPANY_ERROR": {
     "en": "Something went wrong. Enter the details of the person you want to authorise again.",
     "cy": "Aeth rhywbeth o'i le. Mewngofnodwch fanylion y person rydych am ei awdurdodi eto"


### PR DESCRIPTION
WHAT
Defined a new error token: INVITED_USER_GENERIC_ERROR.

WHY
Matomo was reporting instances of this error, yet the error was not defined in the tokens.json file.

HOW
Added an INVITED_USER_GENERIC_ERROR block in tokens.js that mirrors the content of INVITED_USER_ERROR (Unknown error occurred).