### PR TITLE
Chas43 fix spelling mistake

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8263,20 +8263,23 @@
       }
     },
     "node_modules/browserify-sign": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
-      "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.2.tgz",
+      "integrity": "sha512-1rudGyeYY42Dk6texmv7c4VcQ0EsvVbLwZkA+AQB7SxvXxmcD93jcHie8bzecJ+ChDlmAm2Qyu0+Ccg5uhZXCg==",
       "dev": true,
       "dependencies": {
-        "bn.js": "^5.1.1",
-        "browserify-rsa": "^4.0.1",
+        "bn.js": "^5.2.1",
+        "browserify-rsa": "^4.1.0",
         "create-hash": "^1.2.0",
         "create-hmac": "^1.1.7",
-        "elliptic": "^6.5.3",
+        "elliptic": "^6.5.4",
         "inherits": "^2.0.4",
-        "parse-asn1": "^5.1.5",
-        "readable-stream": "^3.6.0",
-        "safe-buffer": "^5.2.0"
+        "parse-asn1": "^5.1.6",
+        "readable-stream": "^3.6.2",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/browserify-sign/node_modules/safe-buffer": {
@@ -31715,20 +31718,20 @@
       }
     },
     "browserify-sign": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
-      "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.2.tgz",
+      "integrity": "sha512-1rudGyeYY42Dk6texmv7c4VcQ0EsvVbLwZkA+AQB7SxvXxmcD93jcHie8bzecJ+ChDlmAm2Qyu0+Ccg5uhZXCg==",
       "dev": true,
       "requires": {
-        "bn.js": "^5.1.1",
-        "browserify-rsa": "^4.0.1",
+        "bn.js": "^5.2.1",
+        "browserify-rsa": "^4.1.0",
         "create-hash": "^1.2.0",
         "create-hmac": "^1.1.7",
-        "elliptic": "^6.5.3",
+        "elliptic": "^6.5.4",
         "inherits": "^2.0.4",
-        "parse-asn1": "^5.1.5",
-        "readable-stream": "^3.6.0",
-        "safe-buffer": "^5.2.0"
+        "parse-asn1": "^5.1.6",
+        "readable-stream": "^3.6.2",
+        "safe-buffer": "^5.2.1"
       },
       "dependencies": {
         "safe-buffer": {

--- a/services/lang/content-tokens.json
+++ b/services/lang/content-tokens.json
@@ -1506,8 +1506,8 @@
     "en": "Industrial action - disruption possible",
     "cy": "Gweithredu diwydiannol - tarfu posib"
   },
-  "SHARED.ifNotRecievedEmail": {
-    "en": "If you still have not recieved the email, we can ",
+  "SHARED.ifNotReceivedEmail": {
+    "en": "If you still have not received the email, we can ",
     "cy": "Os nad ydych wedi derbyn yr e-bost o hyd, gallwn "
   },
   "SHARED.sendSecurityCodeToMobile": {

--- a/services/stages/shared/emailOtp.js
+++ b/services/stages/shared/emailOtp.js
@@ -173,7 +173,7 @@ const emailOtp = (lang, tokens) => ([
           {
             component: 'SpanText',
             props: {
-              children: tokens('SHARED.ifNotRecievedEmail')
+              children: tokens('SHARED.ifNotReceivedEmail')
             }
           },
           {


### PR DESCRIPTION
# Fix spelling mistake related to CHAS-43

On the page where a user enters their OTP code there is a spelling mistake in the sentence: 

`"If you still have not recieved the email, we can "`

I have corrected the spelling of the word `received`

# Bump version of browserify-sign package to address a high level security vulnerability
Bumped version from `4.2.1` to `4.2.2` to address the following high level vulnerability:

[browserify-sign upper bound check issue in `dsaVerify` leads to a signature forgery attack](https://github.com/advisories/GHSA-x9w5-v3q2-3rhw)
