### PR TITLE
remove matomo track event from cancel button

### DIFF
--- a/services/stages/REMOVE_USER_CONFIRM.js
+++ b/services/stages/REMOVE_USER_CONFIRM.js
@@ -104,8 +104,8 @@ const REMOVE_USER_CONFIRM = (lang, tokens) => [
               target: 'IDToken4',
               value: 1
             }
-          },
-          matomo: ['trackEvent', tokens('REMOVE_USER_CONFIRM.[2].PageHeading.doYouWantToRemoveUserDisplayNameS.analytics'), tokens('SHARED.cancel')]
+          }
+          // matomo: ['trackEvent', tokens('REMOVE_USER_CONFIRM.[2].PageHeading.doYouWantToRemoveUserDisplayNameS.analytics'), tokens('SHARED.cancel')]
         }
       }
     ]


### PR DESCRIPTION
# CHAS-26 - Cannot cancel on remove authorised user
We have discovered that this seems to be an issue with Matomo
I have removed the matomo track event from the cancel button on the remove user page to test if this works around the issue. 

Intention here is to test in dev to confirm workaround. 