### PR TITLE
fix: add more missing error tokens

### DIFF
--- a/services/lang/tokens.json
+++ b/services/lang/tokens.json
@@ -518,6 +518,18 @@
     "en": "Enter your password",
     "cy": "Rhowch eich cyfrinair"
   },
+  "LOGIN_PASSWORD_CHECK_ERROR": {
+    "en": "Unknown error occurred",
+    "cy": "Ymddiheuriadau, mae yna broblem gyda'r gwasanaeth"
+  },
+  "RESET_PASSWORD_GENERIC_ERROR": {
+    "en": "Unknown error occurred",
+    "cy": "Ymddiheuriadau, mae yna broblem gyda'r gwasanaeth"
+  },
+  "REMOVE_USER_GENERIC_ERROR": {
+    "en": "Unknown error occurred",
+    "cy": "Ymddiheuriadau, mae yna broblem gyda'r gwasanaeth"
+  },
   "COOKIE_BANNER_HEADING": {
     "en": "Cookies on Companies House services",
     "cy": "Cwcis ar wasanaethau Tŷ'r Cwmnïau"


### PR DESCRIPTION
WHAT
Matomo is reporting missing error tokens in several user journeys.

WHY
This has an impact on analytics. Matomo is not able to retrieve accurate error data.

HOW
Three missing tokens added to `services/lang/tokens.json`

LOGIN_PASSWORD_CHECK_ERROR

RESET_PASSWORD_GENERIC_ERROR

REMOVE_USER_GENERIC_ERROR