### PR TITLE
re-fetch profile on page load

### DIFF
--- a/pages/account/manage/change-phone-number/[pageStep].js
+++ b/pages/account/manage/change-phone-number/[pageStep].js
@@ -56,7 +56,8 @@ const ChangeNumber = ({ lang }) => {
   const { uiFeatures, uiElements, uiStage, stepPageProps, flowHandlers, loading } = useFRFlow(FRFlowConfig)
 
   stepPageProps.changeSuccessPath = generateQueryUrl('/account/manage/', {
-    notifyToken: 'changeNumberSuccess'
+    notifyToken: 'changeNumberSuccess',
+    fetchProfile: true
   })
 
   const { onSubmit, ...restHandlers } = flowHandlers


### PR DESCRIPTION
# Issue Updating Mobile Number

When a user changes their phone number on the manage account page, the phone number is updated successfully, but the old phone number is still displayed to the user on the manage account page. 

This change implements the same fix we released for CHAS-24 in that we re-fetch the users profile information once the change has completed and update session storage to have the new phone number. 
