### PR TITLE
Install packages before security check

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run lint && npm test && npm audit --audit-level=high
+npm install && npm run lint && npm test && npm audit --audit-level=high

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ test-unit:
 
 .PHONY: security-check
 security-check:
+	npm install
 	npm audit --audit-level=high
 
 .PHONY: sonar


### PR DESCRIPTION
# WHAT
Address vulnerabilities for ch-account-ui repo.

# WHY
The pipeline is failing due to an error `npm ERR! audit Your configured registry (https://registry.npmjs.org/) may not support audit requests, or the audit endpoint may be temporarily unavailable`.

# HOW
Install npm packages before running the audit check.